### PR TITLE
Update recordSampleRate after downsampleBuffer

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -64,6 +64,7 @@ module.exports = function (self) {
       offsetResult++;
       offsetBuffer = nextOffsetBuffer;
     }
+    recordSampleRate = exportSampleRate;
     return result;
   }
 


### PR DESCRIPTION
In testing this, I used `startRecording`, `stopRecording`, and `exportWAV` similar to below.
```JavaScript
audioControl.startRecording(() => {
  audioControl.stopRecording()
  audioControl.exportWAV()
}
```
When I call `exportWAV` it appears that `sampleRate` change done in `downsampleBuffer` is not reflected in `encodeWAV`. 

The browser records in 44.1 kHz, and downsampling to 16 kHz, and exporting the WAV, the file has 44.1 kHz encoding and the audio played by Audacity was at 44.1 kHz rate. In Audacity I changed the file rate to 16 kHz and the audio plays correctly. 

By setting `recordSampleRate = exportSampleRate;` after downsampling corrected the issue.